### PR TITLE
videosource() returns file content if strm file

### DIFF
--- a/resources/lib/utils.py
+++ b/resources/lib/utils.py
@@ -85,6 +85,13 @@ def videopath():
 
 
 def videosource():
+        filepath = xbmc.getInfoLabel('Player.Filenameandpath')
+        fileext = os.path.splitext(filepath)
+        if fileext[1] == '.strm':
+                file = xbmcvfs.File(filepath, 'r')
+                source = file.read()
+                file.close()
+                return source # A .strm file contains actual source inside
         return xbmc.getInfoLabel('Player.Folderpath')
 
 


### PR DESCRIPTION
We should return the actual stream url in videosource() when it is a strm file, so it can be compared to addons exclusion, for example.

#15 